### PR TITLE
Fixup graphing

### DIFF
--- a/py_import_cycles/main.py
+++ b/py_import_cycles/main.py
@@ -446,21 +446,21 @@ def _make_graph(
     with d.subgraph() as ds:
         for edge in edges:
             ds.node(
-                edge.from_module.name,
+                str(edge.from_module.name),
                 shape=_get_shape(edge.from_module),
             )
 
             ds.node(
-                edge.to_module.name,
+                str(edge.to_module.name),
                 shape=_get_shape(edge.to_module),
             )
 
             ds.attr("edge", color=edge.edge_color)
 
             if edge.title:
-                ds.edge(edge.from_module.name, edge.to_module.name, edge.title)
+                ds.edge(str(edge.from_module.name), str(edge.to_module.name), edge.title)
             else:
-                ds.edge(edge.from_module.name, edge.to_module.name)
+                ds.edge(str(edge.from_module.name), str(edge.to_module.name))
 
     return d.unflatten(stagger=50)
 


### PR DESCRIPTION
I get the following traceback with the latest version as well as the top of the main branch.

Graphviz expects actual strings (or bytes) and does not attempt to call `str()` on whatever it is passed.

```Traceback (most recent call last):
  File "/home/mlaurin/src/py-import-cycles.git/./py_import_cycles/main.py", line 818, in <module>
    sys.exit(main())
  File "/home/mlaurin/src/py-import-cycles.git/./py_import_cycles/main.py", line 811, in main
    graph = _make_graph(edges, outputs_filepaths)
  File "/home/mlaurin/src/py-import-cycles.git/./py_import_cycles/main.py", line 448, in _make_graph
    ds.node(
  File "/home/mlaurin/src/py-import-cycles.git/.venv/lib/python3.9/site-packages/graphviz/_tools.py", line 171, in wrapper
    return func(*args, **kwargs)
  File "/home/mlaurin/src/py-import-cycles.git/.venv/lib/python3.9/site-packages/graphviz/dot.py", line 195, in node
    name = self._quote(name)
  File "/home/mlaurin/src/py-import-cycles.git/.venv/lib/python3.9/site-packages/graphviz/_tools.py", line 171, in wrapper
    return func(*args, **kwargs)
  File "/home/mlaurin/src/py-import-cycles.git/.venv/lib/python3.9/site-packages/graphviz/quoting.py", line 82, in quote
    if is_html_string(identifier) and not isinstance(identifier, NoHtml):
TypeError: expected string or bytes-like object
```