### PR TITLE
Sandbox/si/main/map path to module name

### DIFF
--- a/py_import_cycles/cli.py
+++ b/py_import_cycles/cli.py
@@ -88,12 +88,14 @@ def main() -> int:
         sys.stderr.write(f"No such directory: {project_path}\n")
         return 1
 
-    outputs_filepaths = get_outputs_filepaths(project_path, args.packages)
+    packages = [Path(p) for p in args.packages]
+
+    outputs_filepaths = get_outputs_filepaths(project_path, packages)
 
     setup_logging(outputs_filepaths.log, args.debug)
 
     logger.info("Get Python files")
-    python_files = iter_python_files(project_path, args.packages)
+    python_files = iter_python_files(project_path, packages)
 
     logger.info("Visit Python files, get imports by module")
     module_factory = ModuleFactory(project_path, dict([entry.split(":") for entry in args.map]))

--- a/py_import_cycles/cli.py
+++ b/py_import_cycles/cli.py
@@ -46,17 +46,6 @@ def _parse_arguments() -> argparse.Namespace:
         help="create graphical representation",
     )
     parser.add_argument(
-        "--map",
-        nargs="+",
-        help=(
-            "hack with symlinks: Sanitize module paths or import statments,"
-            " ie. PREFIX:SHORT, eg.:"
-            " from path.to.SHORT.module -> PREFIX/path/to/SHORT/module.py"
-            " PREFIX/path/to/SHORT/module.py -> path.to.SHORT.module"
-        ),
-        default=[],
-    )
-    parser.add_argument(
         "--project-path",
         required=True,
         help=(
@@ -98,7 +87,8 @@ def main() -> int:
     python_files = iter_python_files(project_path, packages)
 
     logger.info("Visit Python files, get imports by module")
-    module_factory = ModuleFactory(project_path, dict([entry.split(":") for entry in args.map]))
+    module_factory = ModuleFactory(project_path, packages)
+
     imports_by_module = {
         visited.module: visited.imports
         for path in python_files

--- a/py_import_cycles/files.py
+++ b/py_import_cycles/files.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Iterator, NamedTuple, Sequence
 
 
-def iter_python_files(project_path: Path, packages: Sequence[str]) -> Iterator[Path]:
+def iter_python_files(project_path: Path, packages: Sequence[Path]) -> Iterator[Path]:
     if packages:
         for pkg in packages:
             yield from (p.resolve() for p in (project_path / pkg).glob("**/*.py"))
@@ -19,13 +19,13 @@ class OutputsFilepaths(NamedTuple):
     graph: Path
 
 
-def get_outputs_filepaths(project_path: Path, packages: Sequence[str]) -> OutputsFilepaths:
+def get_outputs_filepaths(project_path: Path, packages: Sequence[Path]) -> OutputsFilepaths:
     target_dir = Path.home() / Path(".local", "py_import_cycles", "outputs")
     target_dir.mkdir(parents=True, exist_ok=True)
 
     filename_parts = list(project_path.parts[1:])
     if packages:
-        filename_parts.extend(sorted(packages))
+        filename_parts.extend(sorted(["-".join(p.parts) for p in packages]))
 
     filename = Path("-".join(filename_parts).replace(".", "-"))
 

--- a/tests/unit/test_modules.py
+++ b/tests/unit/test_modules.py
@@ -113,7 +113,7 @@ def test_make_module_from_name_regular_package(
     init_filepath = package_folder / "__init__.py"
     init_filepath.write_text("")
 
-    module = ModuleFactory(project_folder, {}).make_module_from_name(ModuleName(raw_module_name))
+    module = ModuleFactory(project_folder, []).make_module_from_name(ModuleName(raw_module_name))
 
     assert isinstance(module, RegularPackage)
     assert module.path == init_filepath
@@ -137,7 +137,7 @@ def test_make_module_from_name_namespace_package(
     package_folder = project_folder / raw_package_path
     package_folder.mkdir(parents=True, exist_ok=True)
 
-    module = ModuleFactory(project_folder, {}).make_module_from_name(ModuleName(raw_module_name))
+    module = ModuleFactory(project_folder, []).make_module_from_name(ModuleName(raw_module_name))
 
     assert isinstance(module, NamespacePackage)
     assert module.path == package_folder
@@ -164,7 +164,7 @@ def test_make_module_from_name_python_module(
     module_filepath = package_folder / raw_filename
     module_filepath.write_text("")
 
-    module = ModuleFactory(project_folder, {}).make_module_from_name(ModuleName(raw_module_name))
+    module = ModuleFactory(project_folder, []).make_module_from_name(ModuleName(raw_module_name))
 
     assert isinstance(module, PyModule)
     assert module.path == module_filepath
@@ -180,7 +180,7 @@ def test_make_module_from_name_python_module(
 )
 def test_make_module_from_name_error(raw_module_name: str) -> None:
     with pytest.raises(ValueError):
-        ModuleFactory(Path("/path/to/project"), {}).make_module_from_name(
+        ModuleFactory(Path("/path/to/project"), []).make_module_from_name(
             ModuleName(raw_module_name)
         )
 
@@ -202,7 +202,7 @@ def test_make_module_from_path_regular_package(
     init_filepath = package_folder / "__init__.py"
     init_filepath.write_text("")
 
-    module = ModuleFactory(project_folder, {}).make_module_from_path(init_filepath)
+    module = ModuleFactory(project_folder, []).make_module_from_path(init_filepath)
 
     assert isinstance(module, RegularPackage)
     assert module.path == init_filepath
@@ -224,7 +224,7 @@ def test_make_module_from_path_namespace_package(
     package_folder = project_folder / raw_package_path
     package_folder.mkdir(parents=True, exist_ok=True)
 
-    module = ModuleFactory(project_folder, {}).make_module_from_path(package_folder)
+    module = ModuleFactory(project_folder, []).make_module_from_path(package_folder)
 
     assert isinstance(module, NamespacePackage)
     assert module.path == package_folder
@@ -249,7 +249,7 @@ def test_make_module_from_path_python_module(
     module_filepath = package_folder / raw_filename
     module_filepath.write_text("")
 
-    module = ModuleFactory(project_folder, {}).make_module_from_path(module_filepath)
+    module = ModuleFactory(project_folder, []).make_module_from_path(module_filepath)
 
     assert isinstance(module, PyModule)
     assert module.path == module_filepath
@@ -258,4 +258,4 @@ def test_make_module_from_path_python_module(
 
 def test_make_module_from_path_error() -> None:
     with pytest.raises(ValueError):
-        ModuleFactory(Path("/path/to/project"), {}).make_module_from_path(Path("a/b/c"))
+        ModuleFactory(Path("/path/to/project"), []).make_module_from_path(Path("a/b/c"))

--- a/tests/unit/test_walkfs.py
+++ b/tests/unit/test_walkfs.py
@@ -23,7 +23,7 @@ def test_no_files(root: Path) -> None:
     projdir = root / "projdir"
     projdir.mkdir()
 
-    assert frozenset(iter_python_files(root, [projdir.name])) == frozenset()
+    assert frozenset(iter_python_files(root, [projdir])) == frozenset()
 
 
 def test_single_file(root: Path) -> None:
@@ -32,7 +32,7 @@ def test_single_file(root: Path) -> None:
     proj = root / "projdir" / "proj.py"
     setup_py_file(proj)
 
-    assert frozenset(iter_python_files(root, [proj.parent.name])) == {proj}
+    assert frozenset(iter_python_files(root, [proj.parent])) == {proj}
 
 
 def test_multiple_files(root: Path) -> None:
@@ -45,7 +45,7 @@ def test_multiple_files(root: Path) -> None:
     for p in proj:
         setup_py_file(p)
 
-    assert frozenset(iter_python_files(root, [p.parent.name for p in proj])) == proj
+    assert frozenset(iter_python_files(root, [p.parent for p in proj])) == proj
 
 
 def test_multiple_file_with_excludes(root: Path) -> None:
@@ -54,7 +54,7 @@ def test_multiple_file_with_excludes(root: Path) -> None:
     for p in proj | excluded:
         setup_py_file(p)
 
-    assert frozenset(iter_python_files(root, [p.parent.name for p in proj])) == proj
+    assert frozenset(iter_python_files(root, [p.parent for p in proj])) == proj
 
 
 def test_ignore_files_without_py_extention(root: Path) -> None:
@@ -65,7 +65,7 @@ def test_ignore_files_without_py_extention(root: Path) -> None:
     for p in proj | nopy:
         setup_py_file(p)
 
-    assert frozenset(iter_python_files(root, [projdir.name])) == proj
+    assert frozenset(iter_python_files(root, [projdir])) == proj
 
 
 def test_ignore_extra_names_in_second_arg(root: Path) -> None:
@@ -74,7 +74,7 @@ def test_ignore_extra_names_in_second_arg(root: Path) -> None:
     for p in proj:
         setup_py_file(p)
 
-    assert frozenset(iter_python_files(root, [projdir.name, "extra", "args"])) == proj
+    assert frozenset(iter_python_files(root, [projdir, Path("extra"), Path("args")])) == proj
 
 
 def test_recurse_dirs(root: Path) -> None:
@@ -90,4 +90,4 @@ def test_recurse_dirs(root: Path) -> None:
     for p in proj:
         setup_py_file(p)
 
-    assert frozenset(iter_python_files(root, ["p1", "p2"])) == proj
+    assert frozenset(iter_python_files(root, [Path("p1"), Path("p2")])) == proj


### PR DESCRIPTION
Removed --map; packages can be rel paths (to project) und from top to botton I'll try to find out the real package name, eg: "--packages foo/bar/baz": baz is the package name and is used in other modules as "import baz.mod".