### PR TITLE
Skip counting conditionally disabled imports

### DIFF
--- a/py_import_cycles/cli.py
+++ b/py_import_cycles/cli.py
@@ -71,6 +71,12 @@ def _parse_arguments() -> argparse.Namespace:
         default=0,
         help="Tolerate a certain number of cycles, ie. an upper threshold.",
     )
+    parser.add_argument(
+        "--skip-type-checking-guard",
+        action="store_true",
+        default=False,
+        help="Don't count imports in 'if typing.TYPE_CHECKING:' guards.",
+    )
 
     return parser.parse_args()
 
@@ -98,7 +104,8 @@ def main() -> int:
     imports_by_module = {
         visited.module: visited.imports
         for path in python_files
-        if (visited := visit_python_file(module_factory, path)) is not None
+        if (visited := visit_python_file(module_factory, path, args.skip_type_checking_guard))
+        is not None
     }
 
     if _debug():

--- a/py_import_cycles/visitors.py
+++ b/py_import_cycles/visitors.py
@@ -32,6 +32,10 @@ class NodeVisitorImports(ast.NodeVisitor):
             elif isinstance(node.test, ast.Attribute):
                 if node.test.attr == "TYPE_CHECKING":
                     return
+        if isinstance(node.test, ast.Constant):
+            # Skip disabled imports (with if 0, if False, etc.)
+            if not node.test.value:
+                return
         super().generic_visit(node)
 
     def visit_Import(self, node: ast.Import) -> None:

--- a/tests/unit/test_visitors.py
+++ b/tests/unit/test_visitors.py
@@ -36,6 +36,21 @@ from py_import_cycles import visitors
             3,
             False,
         ),
+        (
+            "if 1:\n  import foo\n  import bar",
+            2,
+            False,
+        ),
+        (
+            "if 0:\n  import foo\n  import bar",
+            0,
+            False,
+        ),
+        (
+            "if 0:\n  import foo\n  import bar",
+            0,
+            True,
+        ),
     ],
 )
 def test_visit_python_file(content: str, count: int, skip: bool) -> None:

--- a/tests/unit/test_visitors.py
+++ b/tests/unit/test_visitors.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import ast
+
+import pytest
+
+from py_import_cycles import visitors
+
+
+@pytest.mark.parametrize(
+    ["content", "count", "skip"],
+    [
+        ("", 0, True),
+        ("from foo import bar", 1, True),
+        ("import foo\nimport bar", 2, True),
+        ("import typing\nif typing.TYPE_CHECKING: from foo import bar", 1, True),
+        ("import typing\nif typing.TYPE_CHECKING: from foo import bar", 2, False),
+        ("import typing\nif typing.TYPE_CHECKING: import foo", 1, True),
+        ("import typing\nif typing.TYPE_CHECKING: import foo", 2, False),
+        ("import typing as t\nif t.TYPE_CHECKING: from foo import bar", 1, True),
+        ("import typing as t\nif t.TYPE_CHECKING: from foo import bar", 2, False),
+        ("import typing as t\nif t.TYPE_CHECKING: import foo", 1, True),
+        ("import typing as t\nif t.TYPE_CHECKING: import foo", 2, False),
+        ("from typing import TYPE_CHECKING\nif TYPE_CHECKING: from foo import bar", 1, True),
+        ("from typing import TYPE_CHECKING\nif TYPE_CHECKING: from foo import bar", 2, False),
+        ("from typing import TYPE_CHECKING\nif TYPE_CHECKING: import foo", 1, True),
+        ("from typing import TYPE_CHECKING\nif TYPE_CHECKING: import foo", 2, False),
+        (
+            "from typing import TYPE_CHECKING\nif TYPE_CHECKING:"
+            "\n if 1:\n  import foo\n  import bar",
+            1,
+            True,
+        ),
+        (
+            "from typing import TYPE_CHECKING\nif TYPE_CHECKING:"
+            "\n if 1:\n  import foo\n  import bar",
+            3,
+            False,
+        ),
+    ],
+)
+def test_visit_python_file(content: str, count: int, skip: bool) -> None:
+    tree = ast.parse(content)
+    visitor = visitors.NodeVisitorImports(skip_type_checking=skip)
+    visitor.visit(tree)
+    assert len(visitor.import_stmts) == count


### PR DESCRIPTION
This pull request introduces a new conditional command line switch `skip-type-checking-guard`, which will skip counting imports which are inside a "if typing.TYPE_CHECKING" branch. The default is "False".

It also introduces a change to not count imports inside a "if <falsy_constant>" branch, so "if 0: import foo" or "if False: import foo" will not be counted unconditionally. 