### PR TITLE
pre-commit: Setup pre-commit hooks

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,53 +8,11 @@ on:
 
 
 jobs:
-  bandit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: '3.12'
-      - name: run bandit
-        run: >-
-          uv run bandit --recursive --severity-level=medium py_import_cycles/ tests/
-
-  mypy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: '3.12'
-      - name: run mypy
-        run: uv run mypy py_import_cycles/ tests/
-
-  ruff-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: '3.12'
-      - name: run ruff check
-        run: uv run ruff check --config pyproject.toml --diff
-
-  ruff-format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: '3.12'
-      - name: run ruff format
-        run: uv run ruff format --config pyproject.toml --check --diff
-
   all-checks:
-    if: ${{ !cancelled() }}
-    needs: [bandit, mypy, ruff-check, ruff-format]
     runs-on: ubuntu-latest
     steps:
-      - if: >-
-          ${{ contains(needs.*.result, 'failure')
-          || contains(needs.*.result, 'cancelled') }}
-        run: exit 1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.12'
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+
+  - repo: https://github.com/instrumentl/pre-commit-just
+    rev: 'v0.1'
+    hooks:
+      - id: format-justfile
+
+  - repo: local
+    hooks:
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: unsupported
+        types: [python]
+
+      - id: ruff
+        name: ruff check
+        entry: uv run ruff check --fix
+        language: unsupported
+        types: [python]
+
+      - id: mypy
+        name: mypy
+        entry: uv run mypy py_import_cycles/ tests/
+        language: unsupported
+        types: [python]
+        pass_filenames: false
+
+      - id: bandit
+        name: bandit
+        entry: >-
+          uv run bandit --configfile=pyproject.toml --quiet --recursive --severity-level=medium
+        language: unsupported
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It:
 
 It is conceived for having an indication whether Python packages may have structural weak points.
 
-`py-import-cycles` does not take any Python module finder or loader mechanisms into account. 
+`py-import-cycles` does not take any Python module finder or loader mechanisms into account.
 
 Installation
 ------------

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set positional-arguments := true
+
 default:
     @just --list
 
@@ -5,26 +7,20 @@ clean:
     rm -rf .cache .mypy_cache .pytest_cache .venv ./*.egg-info build
     find py_import_cycles tests -type d -name __pycache__ -print0 | xargs --null --no-run-if-empty rm -rf
 
-test:
-    uv run pytest
+test *args:
+    uv run pytest {{ args }}
 
-check-format:
-    uv run ruff format --check --diff
+lint *args:
+    pre-commit run {{ args }}
 
-mypy:
-    uv run mypy py_import_cycles tests
-
-lint:
-    uv run ruff check --diff
-
-bandit:
-    uv run bandit --configfile=pyproject.toml --quiet --recursive --severity-level=medium py_import_cycles tests
-
-format:
-    uv run ruff format
-    uv run ruff check --fix
+lint-all:
+    pre-commit run --all-files
 
 docs:
     @echo "TODO: generate documentation"
 
-ci: test check-format mypy lint bandit
+ci: lint-all test
+
+update:
+    uv sync
+    pre-commit autoupdate

--- a/py_import_cycles/modules.py
+++ b/py_import_cycles/modules.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from enum import auto, Enum
+from enum import Enum, auto
 from pathlib import Path
 from typing import Final
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dev = ["bandit", "mypy", "pytest", "ruff"]
 [tool.ruff]
 line-length = 100
 
+[tool.ruff.lint]
+extend-select = ["I"]
+
 [tool.ruff.lint.per-file-ignores]
 "e2e_test_inputs/**/*.py" = ["F401"]
 

--- a/tests/unit/test_visitors.py
+++ b/tests/unit/test_visitors.py
@@ -8,11 +8,11 @@ import pytest
 
 from py_import_cycles.modules import ModuleName, PyModule  # pylint: disable=import-error
 from py_import_cycles.visitors import (  # pylint: disable=import-error
+    NodeVisitorImports,
     _AbsImportFromStmt,
     _AbsImportStmt,
     _compute_py_module_from_abs_import_from_stmt,
     _RelImportFromStmt,
-    NodeVisitorImports,
 )
 
 


### PR DESCRIPTION
Setup hooks and adapt justfile and GH to use them. The pre-commit hooks are now our single source of truth.

Architecture
------------

 * uv pins python dependencies.
 * pre-commit uses those pinned dependendencies and pins extra hooks.

 * GH actions are purely a pre-commit user
 * justfile is purely a pre-commit user

How to update the stack
-----------------------

Run `just update`  updates every python dependencies and pre-commit hooks.

How to add a linter
-------------------

If it's a code linter:  Add to `pyproject.toml` and setup a local hook in `.pre-commit-config.yaml`.

It it's a different linter (github actions, justfile, ...):  Add directly to `.pre-commit-config.yaml`.